### PR TITLE
Add get video id

### DIFF
--- a/ios/src/ImageCropPicker.m
+++ b/ios/src/ImageCropPicker.m
@@ -481,6 +481,16 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
     }];
 }
 
+RCT_EXPORT_METHOD(getVideoFromId:(NSString*)assetId options:(NSDictionary *) options
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    [self setConfiguration:options resolver:resolve rejecter:reject];
+    // Getting Video Asset
+    NSArray* localIds = [NSArray arrayWithObjects: assetId, nil];
+    PHAsset * _Nullable videoAsset = [PHAsset fetchAssetsWithLocalIdentifiers:localIds options:nil].firstObject;
+    [self getVideoAsset:videoAsset completion:resolve];
+}
+
 - (NSDictionary*) createAttachmentResponse:(NSString*)filePath withExif:(NSDictionary*) exif withSourceURL:(NSString*)sourceURL withLocalIdentifier:(NSString*)localIdentifier withFilename:(NSString*)filename withWidth:(NSNumber*)width withHeight:(NSNumber*)height withMime:(NSString*)mime withSize:(NSNumber*)size withDuration:(NSNumber*)duration withData:(NSString*)data withRect:(CGRect)cropRect withCreationDate:(NSDate*)creationDate withModificationDate:(NSDate*)modificationDate {
     return @{
         @"path": (filePath && ![filePath isEqualToString:(@"")]) ? filePath : [NSNull null],


### PR DESCRIPTION
I created a new repo with name  and forked it from the Main repo (which has the fix for the camera bug).

We won't be able to move Neils [patch](https://github.com/TeamGuilded/react-native-image-crop-picker/commit/0de0f1f6b920812de598a177b7699bbe72c8971b) into our GuildedNative module because the fix relies on certain functions within the `react-native-image-crop-picker` library